### PR TITLE
Fix to support fully qualified table names

### DIFF
--- a/DotNetFramework.SqlBulkHelpers/SqlBulkHelpers/Database/SqlBulkHelpersDBSchemaLoader.cs
+++ b/DotNetFramework.SqlBulkHelpers/SqlBulkHelpers/Database/SqlBulkHelpersDBSchemaLoader.cs
@@ -89,7 +89,7 @@ namespace SqlBulkHelpers
                 
                 //Dynamically convert to a Lookup for immutable cache of data.
                 //NOTE: Lookup is immutable (vs Dictionary which is not) and performance for lookups is just as fast.
-                var tableDefinitionsLookup = tableDefinitionsList.Where(t => t != null).ToLookup(t => t.TableName.ToLowerInvariant());
+                var tableDefinitionsLookup = tableDefinitionsList.Where(t => t != null).ToLookup(t => t.TableFullyQualifiedName.ToLowerInvariant());
                 return tableDefinitionsLookup;
             }
         }

--- a/DotNetFramework.SqlBulkHelpers/SqlBulkHelpers/Database/SqlBulkHelpersDBSchemaModels.cs
+++ b/DotNetFramework.SqlBulkHelpers/SqlBulkHelpers/Database/SqlBulkHelpersDBSchemaModels.cs
@@ -23,6 +23,7 @@ namespace SqlBulkHelpers
         }
         public String TableSchema { get; private set; }
         public String TableName { get; private set; }
+        public String TableFullyQualifiedName => $"[{TableSchema}].[{TableName}]";
         public IList<SqlBulkHelpersColumnDefinition> Columns { get; private set; }
         public SqlBulkHelpersColumnDefinition IdentityColumn { get; private set; }
 
@@ -44,7 +45,7 @@ namespace SqlBulkHelpers
 
         public override string ToString()
         {
-            return this.TableName;
+            return this.TableFullyQualifiedName;
         }
     }
 

--- a/DotNetFramework.SqlBulkHelpers/SqlBulkHelpers/QueryProcessing/SqlBulkHelpersMergeQueryBuilder.cs
+++ b/DotNetFramework.SqlBulkHelpers/SqlBulkHelpers/QueryProcessing/SqlBulkHelpersMergeQueryBuilder.cs
@@ -22,7 +22,7 @@ namespace SqlBulkHelpers
                     {columnNamesWithoutIdentityCSV},
                     -1 as [{SqlBulkHelpersConstants.ROWNUMBER_COLUMN_NAME}] 
                 INTO [{tempStagingTableName}] 
-                FROM [{tableDefinition.TableName}];
+                FROM [{tableDefinition.TableFullyQualifiedName}];
 
                 ALTER TABLE [{tempStagingTableName}] ADD PRIMARY KEY ([{identityColumnName}]);
 
@@ -62,7 +62,7 @@ namespace SqlBulkHelpers
             //      In general it results in inverting the order of data being sent in Bulk which then resulted in Identity
             //      values being incorrect based on the order of data specified.
             String sqlScriptToExecuteMergeProcess = $@"
-                MERGE [{tableDefinition.TableName}] as target
+                MERGE [{tableDefinition.TableFullyQualifiedName}] as target
 				USING (
 					SELECT TOP 100 PERCENT * 
 					FROM [{tempStagingTableName}] 

--- a/NetStandard.SqlBulkHelpers/SqlBulkHelpers/Database/SqlBulkHelpersDBSchemaLoader.cs
+++ b/NetStandard.SqlBulkHelpers/SqlBulkHelpers/Database/SqlBulkHelpersDBSchemaLoader.cs
@@ -98,7 +98,7 @@ namespace SqlBulkHelpers
 					//Dynamically convert to a Lookup for immutable cache of data.
 					//NOTE: Lookup is immutable (vs Dictionary which is not) and performance for lookups is just as fast.
 					var tableDefinitionsLookup = tableDefinitionsList.Where(t => t != null).ToLookup(
-						t => $"[{t.TableSchema.ToLowerInvariant()}].[{t.TableName.ToLowerInvariant()}]"
+						t => $"{t.TableFullyQualifiedName.ToLowerInvariant()}"
 					);
 					return tableDefinitionsLookup;
 				}

--- a/NetStandard.SqlBulkHelpers/SqlBulkHelpers/Database/SqlBulkHelpersDBSchemaModels.cs
+++ b/NetStandard.SqlBulkHelpers/SqlBulkHelpers/Database/SqlBulkHelpersDBSchemaModels.cs
@@ -23,6 +23,7 @@ namespace SqlBulkHelpers
         }
         public String TableSchema { get; private set; }
         public String TableName { get; private set; }
+        public String TableFullyQualifiedName => $"[{TableSchema}].[{TableName}]";
         public IList<SqlBulkHelpersColumnDefinition> Columns { get; private set; }
         public SqlBulkHelpersColumnDefinition IdentityColumn { get; private set; }
 
@@ -44,7 +45,7 @@ namespace SqlBulkHelpers
 
         public override string ToString()
         {
-            return this.TableName;
+            return this.TableFullyQualifiedName;
         }
     }
 

--- a/NetStandard.SqlBulkHelpers/SqlBulkHelpers/QueryProcessing/SqlBulkHelpersMergeQueryBuilder.cs
+++ b/NetStandard.SqlBulkHelpers/SqlBulkHelpers/QueryProcessing/SqlBulkHelpersMergeQueryBuilder.cs
@@ -34,7 +34,7 @@ namespace SqlBulkHelpers
                     {columnNamesWithoutIdentityCSV},
                     -1 as [{SqlBulkHelpersConstants.ROWNUMBER_COLUMN_NAME}] 
                 INTO [{tempStagingTableName}] 
-                FROM [{tableDefinition.TableName}];
+                FROM {tableDefinition.TableFullyQualifiedName};
 
                 ALTER TABLE [{tempStagingTableName}] ADD PRIMARY KEY ([{identityColumnName}]);
 
@@ -76,7 +76,7 @@ namespace SqlBulkHelpers
             //      custom match Qualifiers; this ensures that data is sorted in a way that postprocessing
             //      can occur & be validated as expected.
             String sqlScriptToExecuteMergeProcess = $@"
-                MERGE [{tableDefinition.TableName}] as target
+                MERGE {tableDefinition.TableFullyQualifiedName} as target
 				USING (
 					SELECT TOP 100 PERCENT * 
 					FROM [{tempStagingTableName}] 


### PR DESCRIPTION
The code is currently throwing "Invalid object name {TableName}" exception when fully qualified table name with non default schema is used. This PR fixes it.