### PR TITLE
Refactor and enhance to now avoid Schema Locks as default behavior in…

### DIFF
--- a/NetStandard.SqlBulkHelpers/Database/TableNameTerm.cs
+++ b/NetStandard.SqlBulkHelpers/Database/TableNameTerm.cs
@@ -23,10 +23,19 @@ namespace SqlBulkHelpers
         public string FullyQualifiedTableName { get; }
 
         public override string ToString() => FullyQualifiedTableName;
-        public bool Equals(TableNameTerm other) => FullyQualifiedTableName.Equals(other.FullyQualifiedTableName);
-        public bool EqualsIgnoreCase(TableNameTerm other) => FullyQualifiedTableName.Equals(other.FullyQualifiedTableName, StringComparison.OrdinalIgnoreCase);
-        public TableNameTerm SwitchSchema(string newSchema) => new TableNameTerm(newSchema, TableName);
-        
+
+        public bool Equals(TableNameTerm other)
+            => FullyQualifiedTableName.Equals(other.FullyQualifiedTableName);
+
+        public bool EqualsIgnoreCase(TableNameTerm other)
+            => FullyQualifiedTableName.Equals(other.FullyQualifiedTableName, StringComparison.OrdinalIgnoreCase);
+
+        public TableNameTerm SwitchSchema(string newSchema)
+            => new TableNameTerm(newSchema, TableName);
+
+        public TableNameTerm ApplyNamePrefixOrSuffix(string prefix = null, string suffix = null)
+             => new TableNameTerm(SchemaName, string.Concat(prefix?.Trim() ?? string.Empty, TableName, suffix?.Trim() ?? string.Empty));
+
         //Handle Automatic String conversions for simplified APIs...
         public static implicit operator string(TableNameTerm t) => t.ToString();
 

--- a/NetStandard.SqlBulkHelpers/MaterializedData/CloneTableInfo.cs
+++ b/NetStandard.SqlBulkHelpers/MaterializedData/CloneTableInfo.cs
@@ -30,9 +30,9 @@ namespace SqlBulkHelpers.MaterializedData
             => new CloneTableInfo(SourceTable, MakeTableNameUniqueInternal(TargetTable));
 
         private static TableNameTerm MakeTableNameUniqueInternal(TableNameTerm tableNameTerm)
-            => TableNameTerm.From(tableNameTerm.SchemaName, $"{tableNameTerm.TableName}_Copy_{IdGenerator.NewId(10)}");
+            => TableNameTerm.From(tableNameTerm.SchemaName, string.Concat(tableNameTerm.TableName, "_", IdGenerator.NewId(10)));
 
-        public static CloneTableInfo From<TSource, TTarget>(string sourceTableName = null, string targetTableName = null)
+        public static CloneTableInfo From<TSource, TTarget>(string sourceTableName = null, string targetTableName = null, string targetPrefix = null, string targetSuffix = null)
         {
             //If the generic type is ISkipMappingLookup then we must have a valid sourceTableName specified as a param...
             if (SqlBulkHelpersProcessingDefinition.SkipMappingLookupType.IsAssignableFrom(typeof(TSource)))
@@ -46,7 +46,7 @@ namespace SqlBulkHelpers.MaterializedData
                 ? sourceTableName
                 : targetTableName;
 
-            //If the generic type is ISkipMappingLookup then we must have a valid sourceTableName specified as a param...
+            //If the generic type is ISkipMappingLookup then we must have a valid validTargetTableName specified as a param...
             if (SqlBulkHelpersProcessingDefinition.SkipMappingLookupType.IsAssignableFrom(typeof(TTarget)))
             {
                 //We validate the valid target table name but if it's still blank then we throw an Argument
@@ -54,14 +54,14 @@ namespace SqlBulkHelpers.MaterializedData
                 validTargetTableName.AssertArgumentIsNotNullOrWhiteSpace(nameof(targetTableName));
             }
 
-            var targetTable = TableNameTerm.From<TTarget>(targetTableName ?? sourceTableName);
+            var targetTable = TableNameTerm.From<TTarget>(targetTableName ?? sourceTableName).ApplyNamePrefixOrSuffix(targetPrefix, targetSuffix);
             return new CloneTableInfo(sourceTable, targetTable);
         }
 
-        public static CloneTableInfo From(string sourceTableName, string targetTableName = null)
-            => From<ISkipMappingLookup, ISkipMappingLookup>(sourceTableName, targetTableName);
+        public static CloneTableInfo From(string sourceTableName, string targetTableName = null, string targetPrefix = null, string targetSuffix = null)
+            => From<ISkipMappingLookup, ISkipMappingLookup>(sourceTableName, targetTableName, targetPrefix, targetSuffix);
 
-        public static CloneTableInfo ForNewSchema(TableNameTerm sourceTable, string targetSchemaName)
-            => new CloneTableInfo(sourceTable, sourceTable.SwitchSchema(targetSchemaName));
+        public static CloneTableInfo ForNewSchema(TableNameTerm sourceTable, string targetSchemaName, string targetTablePrefix = null, string targetTableSuffix = null)
+            => new CloneTableInfo(sourceTable, sourceTable.SwitchSchema(targetSchemaName).ApplyNamePrefixOrSuffix(targetTablePrefix, targetTableSuffix));
     }
 }

--- a/NetStandard.SqlBulkHelpers/MaterializedData/IMaterializeDataContextCompletionSource.cs
+++ b/NetStandard.SqlBulkHelpers/MaterializedData/IMaterializeDataContextCompletionSource.cs
@@ -1,9 +1,10 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 
 namespace SqlBulkHelpers.MaterializedData
 {
     public interface IMaterializeDataContextCompletionSource : IMaterializeDataContext
     {
-        Task FinishMaterializeDataProcessAsync();
+        Task FinishMaterializeDataProcessAsync(SqlTransaction sqlTransaction);
     }
 }

--- a/NetStandard.SqlBulkHelpers/MaterializedData/MaterializedDataScriptBuilder.cs
+++ b/NetStandard.SqlBulkHelpers/MaterializedData/MaterializedDataScriptBuilder.cs
@@ -52,7 +52,7 @@ namespace SqlBulkHelpers.MaterializedData
             return this;
         }
 
-        public MaterializedDataScriptBuilder DropTable(TableNameTerm tableName)
+        public MaterializedDataScriptBuilder DropTableIfExists(TableNameTerm tableName)
         {
             tableName.AssertArgumentIsNotNull(nameof(tableName));
             ScriptBuilder.Append($@"
@@ -63,7 +63,7 @@ namespace SqlBulkHelpers.MaterializedData
             return this;
         }
 
-        public MaterializedDataScriptBuilder TruncateTable(TableNameTerm tableName)
+        public MaterializedDataScriptBuilder TruncateTableIfExists(TableNameTerm tableName)
         {
             tableName.AssertArgumentIsNotNull(nameof(tableName));
             ScriptBuilder.Append($@"
@@ -212,7 +212,7 @@ namespace SqlBulkHelpers.MaterializedData
             if (ifExists == IfExists.Recreate)
             {
                 addTableCopyScript = true;
-                DropTable(targetTable);
+                DropTableIfExists(targetTable);
             }
             else if (ifExists == IfExists.StopProcessingWithException)
             {

--- a/NetStandard.SqlBulkHelpers/NetStandard.SqlBulkHelpers.csproj
+++ b/NetStandard.SqlBulkHelpers/NetStandard.SqlBulkHelpers.csproj
@@ -8,16 +8,20 @@
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>BBernard / CajunCoding</Authors>
     <Company>CajunCoding</Company>
-	<Version>2.2.3</Version>
+	<Version>2.3.0</Version>
 	<PackageProjectUrl>https://github.com/cajuncoding/SqlBulkHelpers</PackageProjectUrl>
 	<RepositoryUrl>https://github.com/cajuncoding/SqlBulkHelpers</RepositoryUrl>
     <Description>A library for easy, efficient and high performance bulk insert and update of data, into a Sql Database, from .Net applications. By leveraging the power of the SqlBulkCopy classes with added support for Identity primary key table columns this library provides a greatly simplified interface to process Identity based Entities with Bulk Performance with the wide compatibility of .NetStandard 2.0.</Description>
 	<PackageTags>sql server database table bulk insert update identity column sqlbulkcopy orm dapper linq2sql materialization materialized data view materialized-data materialized-view sync replication replica readonly</PackageTags>
     <PackageReleaseNotes>
+		- Changed default behaviour to no longer clone tables/schema inside a Transaction which creates a full Schema Lock -- as this greatly impacts Schema aware ORMs such as SqlBulkHelpers, RepoDb, etc.
+		- New separate methods is now added to handle the CleanupMaterializeDataProcessAsync() but must be explicitly called as it is no longer implicitly called with FinishMaterializeDataProcessAsync().
+		- Added new configuration value to control if Schema copying/cloning (for Loading Tables) is inside or outide the Transaction (e.g. SchemaCopyMode.InsideTransactionAllowSchemaLocks vs OutsideTransactionAvoidSchemaLocks).
+		- Fix bug in ReSeedTableIdentityValueWithMaxIdAsync() when the Table is Empty so that it now defaults to value of 1.
+
+		Prior Relese Notes:
 		- Fixed a Bug where Identity Column Value was not correctly synced after Materialization Process is completing.
 		- Added new Helper API to quickly Sync the Identity column value with the current MAX Id value of the column (ensuring it's valid after populating additional data); This is useful if you override Identity values for a full Table refresh, but then want to later insert data into the table.
-
-	    Prior Relese Notes:
 		- Improved namespace for SqlBulkHelpers.CustomExtensions to reduce risk of conflicts with similar existing extensions.
 		- Restored support for SqlConnection Factory (simplified now as a Func&lt;SqlConnection&gt; when manually using the SqlDbSchemaLoader to dynamically retrieve Table Schema definitions for performance.
 		- Added support for other Identity column data types including (INT, BIGINT, SMALLINT, &amp; TINYINT); per feature request (https://github.com/cajuncoding/SqlBulkHelpers/issues/10).

--- a/NetStandard.SqlBulkHelpers/SqlBulkHelpersConfig.cs
+++ b/NetStandard.SqlBulkHelpers/SqlBulkHelpersConfig.cs
@@ -10,6 +10,12 @@ namespace SqlBulkHelpers
         public const int DefaultMaxConcurrentConnections = 5;
     }
 
+    public enum SchemaCopyMode
+    {
+        OutsideTransactionAvoidSchemaLocks = 1,
+        InsideTransactionAllowSchemaLocks = 2,
+    }
+
     public interface ISqlBulkHelpersConfig
     {
         int SqlBulkBatchSize { get; } //General guidance is that 2000-5000 is efficient enough.
@@ -22,8 +28,17 @@ namespace SqlBulkHelpers
         int MaterializeDataStructureProcessingTimeoutSeconds { get; }
         int MaterializedDataSwitchTableWaitTimeoutMinutes { get; }
         SwitchWaitTimeoutAction MaterializedDataSwitchTimeoutAction { get; }
+
         string MaterializedDataLoadingSchema { get; }
+        string MaterializedDataLoadingTablePrefix { get; }
+        string MaterializedDataLoadingTableSuffix { get; }
+
         string MaterializedDataDiscardingSchema { get; }
+        string MaterializedDataDiscardingTablePrefix { get; }
+        string MaterializedDataDiscardingTableSuffix { get; }
+
+        SchemaCopyMode MaterializedDataSchemaCopyMode { get; }
+        bool MaterializedDataMakeSchemaCopyNamesUnique { get; }
         bool IsCloningIdentitySeedValueEnabled { get; }
 
         ISqlBulkHelpersConnectionProvider ConcurrentConnectionFactory { get; }
@@ -125,8 +140,17 @@ namespace SqlBulkHelpers
         public int MaterializeDataStructureProcessingTimeoutSeconds { get; set; } = 30;
         public int MaterializedDataSwitchTableWaitTimeoutMinutes { get; set; } = 1;
         public SwitchWaitTimeoutAction MaterializedDataSwitchTimeoutAction { get; } = SwitchWaitTimeoutAction.Abort;
+        public SchemaCopyMode MaterializedDataSchemaCopyMode { get; set; } = SchemaCopyMode.OutsideTransactionAvoidSchemaLocks;
+        public bool MaterializedDataMakeSchemaCopyNamesUnique { get; set; } = true;
+
         public string MaterializedDataLoadingSchema { get; set; } = "materializing_load";
+        public string MaterializedDataLoadingTablePrefix { get; set; } = string.Empty;
+        public string MaterializedDataLoadingTableSuffix { get; set; } = "_Loading";
+
         public string MaterializedDataDiscardingSchema { get; set; } = "materializing_discard";
+        public string MaterializedDataDiscardingTablePrefix { get; set; } = string.Empty;
+        public string MaterializedDataDiscardingTableSuffix { get; set; } = "_Discarding";
+
         public bool IsCloningIdentitySeedValueEnabled { get; set; } = true;
         public ISqlBulkHelpersConnectionProvider ConcurrentConnectionFactory { get; set; } = null;
 

--- a/SqlBulkHelpers.Tests/IntegrationTests/MaterializeDataTests/CloneTablesTests.cs
+++ b/SqlBulkHelpers.Tests/IntegrationTests/MaterializeDataTests/CloneTablesTests.cs
@@ -31,7 +31,6 @@ namespace SqlBulkHelpers.IntegrationTests
                 Assert.IsNotNull(cloneInfo);
                 Assert.AreEqual(TestHelpers.TestTableName, cloneInfo.SourceTable.TableName);
                 Assert.AreNotEqual(cloneInfo.SourceTable.FullyQualifiedTableName, cloneInfo.TargetTable.FullyQualifiedTableName);
-                Assert.IsTrue(cloneInfo.TargetTable.TableName.Contains("_Copy_", StringComparison.OrdinalIgnoreCase));
 
                 //Validate the schema of the cloned table...
                 Assert.IsNotNull(sourceTableSchema);
@@ -87,6 +86,14 @@ namespace SqlBulkHelpers.IntegrationTests
                 //Validate that the new table has No Data!
                 var targetTableCount = await sqlConn.CountAllAsync(tableName: cloneInfo.TargetTable).ConfigureAwait(false);
                 Assert.AreEqual(0, targetTableCount);
+
+                //CLEANUP The Cloned Table so that other Tests Work as expected (e.g. Some tests validate Referencing FKeys, etc.
+                //  that are now increased with the table clone).
+                await using (var sqlTransForCleanup = (SqlTransaction)await sqlConn.BeginTransactionAsync().ConfigureAwait(false))
+                {
+                    await sqlTransForCleanup.DropTableAsync(cloneInfo.TargetTable).ConfigureAwait(false);
+                    await sqlTransForCleanup.CommitAsync().ConfigureAwait(false);
+                }
             }
         }
 
@@ -121,6 +128,14 @@ namespace SqlBulkHelpers.IntegrationTests
 
                 //Ensure both Source & Target contain the same number of records!
                 Assert.AreEqual(sourceTableCount, targetTableCount);
+
+                //CLEANUP The Cloned Table so that other Tests Work as expected (e.g. Some tests validate Referencing FKeys, etc.
+                //  that are now increased with the table clone).
+                await using (var sqlTransForCleanup = (SqlTransaction)await sqlConn.BeginTransactionAsync().ConfigureAwait(false))
+                {
+                    await sqlTransForCleanup.DropTableAsync(cloneInfo.TargetTable).ConfigureAwait(false);
+                    await sqlTransForCleanup.CommitAsync().ConfigureAwait(false);
+                }
             }
         }
 

--- a/SqlBulkHelpers.Tests/IntegrationTests/MaterializeDataTests/TableIdentityColumnApiTests.cs
+++ b/SqlBulkHelpers.Tests/IntegrationTests/MaterializeDataTests/TableIdentityColumnApiTests.cs
@@ -109,7 +109,6 @@ namespace SqlBulkHelpers.Tests.IntegrationTests.MaterializeDataTests
             var sqlConnectionString = SqlConnectionHelper.GetSqlConnectionString();
             ISqlBulkHelpersConnectionProvider sqlConnectionProvider = new SqlBulkHelpersConnectionProvider(sqlConnectionString);
 
-            long initialIdentitySeedValue = 0;
             var firstNewIdentitySeedValue = 555888;
             var secondNewIdentitySeedValue = 888444;
 


### PR DESCRIPTION
Refactor and enhance to now avoid Schema Locks as default behavior in the ExecuteMaterializeDataProcessAsync(); but is configurable. The the new MaterializedDataSchemaCopyMode config value controls if Schema copying/cloning (for Loading/Discarding Tables) is inside or outside the Transaction (e.g. SchemaCopyMode.InsideTransactionAllowSchemaLocks vs OutsideTransactionAvoidSchemaLocks). New separate methods is now added to handle the CleanupMaterializeDataProcessAsync() but must be explicitly called as it is no longer implicitly called with FinishMaterializeDataProcessAsync(). Fix bug in ReSeedTableIdentityValueWithMaxIdAsync() when the Table is Empty so that it now defaults to value of 1. Added support to customize the Prefix & Suffix of cloned tables in the Materialized Data process for the Loading table name & Discarding table name (e.g. MaterializedDataLoadingTablePrefix, MaterializedDataDiscardingTablePrefix, etc.).

All Unit Tests are passing, and Nuget Package has been updated now as v2.3.0.