### PR TITLE
Fix collation conflict

### DIFF
--- a/NetStandard.SqlBulkHelpers/Database/SqlQueries/QueryDBTableSchemaBasicDetailsJson.sql
+++ b/NetStandard.SqlBulkHelpers/Database/SqlQueries/QueryDBTableSchemaBasicDetailsJson.sql
@@ -12,7 +12,7 @@
 			AND t.TABLE_CATALOG = DB_NAME()
 			AND t.TABLE_NAME = CASE
 				WHEN @IsTempTable = 0 THEN @TableName
-				ELSE (SELECT TOP (1) t.[name] FROM tempdb.sys.objects t WHERE t.[object_id] = OBJECT_ID(CONCAT(N'tempdb.[', @TableSchema, '].[', @TableName, ']')))
+				ELSE (SELECT TOP (1) t.[name] FROM tempdb.sys.objects t WHERE t.[object_id] = OBJECT_ID(CONCAT(N'tempdb.[', @TableSchema, '].[', @TableName, ']'))) COLLATE DATABASE_DEFAULT
 			END
 	)
 	SELECT

--- a/NetStandard.SqlBulkHelpers/Database/SqlQueries/QueryDBTableSchemaExtendedDetailsJson.sql
+++ b/NetStandard.SqlBulkHelpers/Database/SqlQueries/QueryDBTableSchemaExtendedDetailsJson.sql
@@ -12,7 +12,7 @@
 			AND t.TABLE_CATALOG = DB_NAME()
 			AND t.TABLE_NAME = CASE
 				WHEN @IsTempTable = 0 THEN @TableName
-				ELSE (SELECT TOP (1) t.[name] FROM tempdb.sys.objects t WHERE t.[object_id] = OBJECT_ID(CONCAT(N'tempdb.[', @TableSchema, '].[', @TableName, ']')))
+				ELSE (SELECT TOP (1) t.[name] FROM tempdb.sys.objects t WHERE t.[object_id] = OBJECT_ID(CONCAT(N'tempdb.[', @TableSchema, '].[', @TableName, ']'))) COLLATE DATABASE_DEFAULT
 			END
 	)
 	SELECT


### PR DESCRIPTION
The QueryDBTableSchema* queries result in the following exception when my db and temp db collations do not match:
`Cannot resolve the collation conflict between "tempdb_collation" and "my_db_colletion" in the equal to operation.`

This fixes the error. I didn't test with temp tables though.
